### PR TITLE
Another Quickfix for wrong advancement

### DIFF
--- a/src/main/resources/rewards.yml
+++ b/src/main/resources/rewards.yml
@@ -483,7 +483,7 @@ minecraft:
       points: 75
       items:
         GOLDEN_APPLE: 10
-    allay_deliver_cake_to_noteblock:
+    allay_deliver_cake_to_note_block:
       points: 10
       items:
         GOLDEN_CARROT: 5


### PR DESCRIPTION
Found another one ;)
allay_deliver_cake_to_noteblock -> allay_deliver_cake_to_note_block